### PR TITLE
Remove multiple

### DIFF
--- a/src/commands/tick-rm.js
+++ b/src/commands/tick-rm.js
@@ -2,7 +2,7 @@ export default rm
 
 import Entry from '../entry'
 import PouchDB from 'pouchdb'
-import {write} from './output'
+import { getOutputs } from './output'
 import chalk from 'chalk'
 import conf from '../config'
 
@@ -21,6 +21,8 @@ function rm (yargs) {
 
 function removeEntry (doc) {
   const e = Entry.fromJSON(doc)
-  write(e)
-  return db.remove(doc).then(result => { console.log(chalk.bgRed('removed')) })
+  return db.remove(doc).then(result => { 
+    let { detailed } = getOutputs(e)
+    console.log(chalk.bgRed('removed') + ' ' + detailed)
+  })
 }


### PR DESCRIPTION
Resolves #7 
- Allows tickbin to support deletion of multiple records at once (Ex: `tick rm 123 456`)
- Changes the output format so that "removed" is on the same line as the entry
- Changes such that the entry is only printed once the success callback is called, rather than immediately

![image](https://cloud.githubusercontent.com/assets/2072672/12028273/75084268-ad89-11e5-92b8-045c3df0a998.png)

@jonotron Are you OK with this output format change? It's slightly inconsistent with how the `log` output messages look now (they print the "saved" on a separate line), but it looks better when removing multiple records I think.
