### PR TITLE
date range support for tick list with -d flag

### DIFF
--- a/src/commands/tick-list.js
+++ b/src/commands/tick-list.js
@@ -6,6 +6,7 @@ import moment from 'moment'
 import _ from 'lodash'
 import chalk from 'chalk'
 import format from '../time'
+import chrono from 'chrono-node'
 import db from '../db'
 
 function list (yargs) {
@@ -25,10 +26,22 @@ function list (yargs) {
   .alias('h', 'help')
   .argv
 
+  let dates = chrono.parse(argv.date)[0] || [{}]
+  // default to most recent 7 days
+  let start = moment().subtract(6, 'days').startOf('day').toArray()
+  let end   = moment().endOf('day').toArray();
+  if (dates.start && dates.end) {
+    start = moment(dates.start.date()).startOf('day').toArray()
+    end   = moment(dates.end.date()).endOf('day').toArray()
+  }
+
   db.query(mapDate, {
     include_docs: true,
-    descending: true
+    descending: true,
+    startkey: end, // decending, so we start at recent dates
+    endkey: start
   }).then(_.partial(writeEntries, hashTags(argv.tag)))
+
 
 }
 


### PR DESCRIPTION
uses chrono to parse string passed into `-d`/`--date` flag and filters list by that range (inclusively)

e.g. (from #31)

``` bash
tick list -d "today - today" # all entries for today
tick list -d "jan 1-31" # all entries for month of January
tick list -d "nov 1 - dec 31" # all entries for months of Nov - Dec
```

By default, if nothing is provided or the `-d` can not be parsed, it returns only the last 7 days (including today) worth of entries
