### PR TITLE
Hot Fix: appening data directory twice for default path

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -5,7 +5,7 @@ import mkdirp from 'mkdirp'
 import untildify from 'untildify'
 
 const conf = rc('tickbin', {
-  local: '~/.tickbin/data'
+  local: '~/.tickbin'
 })
 
 conf.local = untildify(conf.local)


### PR DESCRIPTION
Accidentally appended `/data` onto the default path twice.
