### PR TITLE
Color tags inline

### DIFF
--- a/src/commands/output.js
+++ b/src/commands/output.js
@@ -22,12 +22,12 @@ function getOutputs(entry) {
   const time = `${timeFrom.format('hh:mma')}-${timeTo.format('hh:mma')}`
   const duration = chalk.green(format(entry.duration.minutes))
   const msg = entry.message
-    .replace(hashPattern, '')
+    .replace(hashPattern, chalk.cyan('$1'))
     .replace(timePattern, '')
   const tags = chalk.cyan([...entry.tags].join(' '))
 
-  const detailed = `${id} ${date} ${time} ${duration} ${msg} ${tags}`
-  const simple = `${id} ${time} ${duration} ${msg} ${tags}`
+  const detailed = `${id} ${date} ${time} ${duration} ${msg}`
+  const simple = `${id} ${time} ${duration} ${msg}`
 
   return {id, date, duration, msg, tags, detailed, simple}
 }

--- a/src/entry.js
+++ b/src/entry.js
@@ -3,7 +3,7 @@ import shortid from 'shortid'
 import moment from 'moment'
 import parser from './parser'
 
-export const hashPattern = /#\w+/g
+export const hashPattern = /(#\w+)/g
 export const version = 1
 export default class Entry {
   constructor(message, opts = {}) {


### PR DESCRIPTION
instead of stripping tags and appending them, color them inline to improved readability

![tickbin zsh 2016-01-17 12-09-56](https://cloud.githubusercontent.com/assets/349600/12379670/99dd77c2-bd13-11e5-97c3-f06826eb95f5.jpg)

fixes #53 
