### PR TITLE
run all tests with tape cli

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "clean": "rm -rf build/*",
     "build": "babel src --out-dir build/",
     "watch": "babel src --watch --out-dir build/",
-    "test": "node build/test/entry.test.js | tap-spec && node build/test/parser.test.js | tap-spec",
+    "test": "tape build/test/*.js | tap-spec",
 
     "prebuild": "npm run clean",
     "prewatch": "npm run clean"


### PR DESCRIPTION
this produces aggregate results:

![tickbin zsh 2016-01-18 11-14-40](https://cloud.githubusercontent.com/assets/349600/12400434/eb11cf5a-bdd4-11e5-9cb1-a5bc3140cffb.jpg)

and now it runs all tests, making it much easier to add tests.
