### PR TITLE
Optional no flag message

### DIFF
--- a/src/commands/tick-log.js
+++ b/src/commands/tick-log.js
@@ -20,10 +20,11 @@ function log (yargs) {
   .alias('h', 'help')
   .argv
 
-  let {message, date} = argv
+  let message
+  let { date } = argv
   date = chrono.parseDate(date)
 
-  if (argv._[1] && !message) {
+  if (argv._[1]) {
     message = argv._[1]
   }
 


### PR DESCRIPTION
Adds support for not explicitly flagging `-m`

![screen shot 2016-01-20 at 2 27 24 pm](https://cloud.githubusercontent.com/assets/3250463/12465246/f3db21b4-bf81-11e5-87b4-2e1075d9f422.png)

@MemoryLeaf/devs Thoughts on the usage description? I wasn't sure if there would be a good way of expanding on how to log without the flag. Looked through the **yargs** docs and didn't see much on documenting for the non-hyphenated values.

Resolves #72
