### PR TITLE
Update babel to only transpile the required features

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,9 @@
 {
-  "presets": ["es2015"]
+  "plugins": [
+    "transform-es2015-modules-commonjs",
+    "transform-es2015-destructuring",
+    "transform-es2015-parameters",
+    "transform-es2015-spread"
+  ]
 }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,10 @@
   "devDependencies": {
     "babel-cli": "^6.3.17",
     "babel-eslint": "^5.0.0-beta6",
-    "babel-preset-es2015": "^6.3.13",
+    "babel-plugin-transform-es2015-destructuring": "^6.6.5",
+    "babel-plugin-transform-es2015-modules-commonjs": "^6.7.0",
+    "babel-plugin-transform-es2015-parameters": "^6.7.0",
+    "babel-plugin-transform-es2015-spread": "^6.6.5",
     "eslint": "^1.10.3",
     "nock": "^5.2.1",
     "sinon": "^1.17.2",


### PR DESCRIPTION
A lot of the features that were transpiled are supported in Node 4.3.x.

Resolves #121
