### PR TITLE
Make `eslintrc` closer to standard, compatibility with Jetbrains IDEs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,8 @@
+{
+  "parser": "babel-eslint",
+  "rules": {
+    "semi": [2, "never"],
+    "no-unreachable": 2,
+    "no-unexpected-multiline": 2
+  }
+}

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,0 @@
-module.exports = {
-  'parser': 'babel-eslint',
-  'rules': {
-    'semi': [2, 'never'],
-    'no-unreachable': 2,
-    'no-unexpected-multiline': 2
-  }
-}


### PR DESCRIPTION
In [most](https://github.com/james-proxy/james) [projects](https://github.com/airbnb/enzyme), the `.eslintrc` file has no file extension, and it declares everything with simple JSON.

Though you're _allowed_ to provide a file extension and make it an actual `.js` file, it's simpler and more compatible if you keep it JSON with no file extension..

Besides, WebStorm's ESlint plugin will miss the file if it has an extension.
![2016-03-16-140950_676x70_scrot](https://cloud.githubusercontent.com/assets/7784737/13813234/c0b6b8e0-eb80-11e5-9f28-a1178a30fee3.png)
