### PR TITLE
Simplify checkCommand

### DIFF
--- a/src/tick.js
+++ b/src/tick.js
@@ -23,9 +23,7 @@ yargs
 .help('h')
 .argv
 
-function checkCommand (argv) {
-  const validArgs = [ 'log', 'list', 'rm' ]
-  if (validArgs.indexOf(argv._[0]) == -1) {
-    throw new Error('you must provide a valid command')
-  }
+function checkCommand () {
+  // Only executed when no other commands are matched. Therefore, when executed, an invalid command was provided
+  throw new Error('you must provide a valid command')
 }


### PR DESCRIPTION
This one's a little tricky.

I did a little investigation, and it was weird that the current implementation of `checkCommand` only asserts that a subset of all possible commands were provided:
```
const validArgs = [ 'log', 'list', 'rm' ]
```
After looking into it a little further, it turns out that `command()` "short-circuits", or whatever that's called: if a command is matched, then `checkCommand` is never run! Therefore, conversely, if `checkCommand` _is_ executed, then no `command()` was executed (so an invalid command was provided).

I couldn't see anything describing this behaviour in [`yargs`](https://github.com/yargs/yargs), so that perhaps it's an implementation flaw, and this PR's optimizations should __not__ be made. At the same time... maybe it's on purpose?

Either way, `checkCommand` needs to be better, because it's confusing in its current state