### PR TITLE
Add .tickbinrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+.tickbinrc
 tickbin
 build


### PR DESCRIPTION
This means that developers can use `build/tick.js` with a directory-local `.tickbinrc` that contains separate `API ` and `LOCAL` configuration variables than the system-wide one.

Therefore developers can track their time in a globally installed tickbin without worrying about destroying their database while developing.