### PR TITLE
[breaking] specify date naturally in the entry message

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ logs time entries
 
 ```shell
 tick log "8am-12pm fixed a bunch of bugs" # logs time entry for today
-tick log -d yesterday "9pm-11pm late night code jamming" # log time entry for yesterday
-tick log -d "Jan 1" "12am-1am partied!" # log time for Jan 1
+tick log "9pm-11pm yesterday late night code jamming" # log time entry for yesterday
+tick log "Jan 1 12am-1am partied!" # log time for Jan 1
 tick log "12pm-1pm great #lunch at Mervo's" # add #tags anywhere
 ```
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "dependencies": {
     "axios": "^0.9.0",
     "chalk": "^1.1.1",
-    "chrono-node": "^1.1.5",
+    "chrono-node": "^1.1.6",
     "csv-stringify": "^1.0.2",
     "duration": "^0.2.0",
     "forward-events": "0.0.1",

--- a/src/commands/tick-log.js
+++ b/src/commands/tick-log.js
@@ -10,18 +10,13 @@ function log (yargs) {
   let argv = yargs
   .usage('Usage: tick log [options] [message]')
   .example('tick log "8am-12pm fixing bugs #tickbin"', 'log work for current day')
-  .example('tick log -d "Jan 22" "11am-1pm fixing bugs #tickbin"', 'log work for Jan 22')
-  .option('d', {
-    alias: 'date',
-    describe: 'date for tick'
-  })
+  .example('tick log "Jan 22 11am-1pm fixing bugs #tickbin"', 'log work for Jan 22')
+  .example('tick log "yesterday 4-5pm learning javascript #dev"', 'log work for yesterday')
   .help('h')
   .alias('h', 'help')
   .argv
 
   let message
-  let { date } = argv
-  date = chrono.parseDate(date)
 
   if (argv._[1]) {
     message = argv._[1]
@@ -33,12 +28,12 @@ function log (yargs) {
     prompt.start()
     prompt.get('message', function(err, res) {
       if (!err){
-        createEntry(db, res.message, {date})
+        createEntry(db, res.message)
         .then(writeSaved)
       }
     })
   } else {
-    createEntry(db, message, {date})
+    createEntry(db, message)
     .then(writeSaved)
   }
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -5,7 +5,7 @@ import impliedAMEndRefiner from './refiners/impliedAMEndRefiner'
 import impliedPMStartRefiner from './refiners/impliedPMStartRefiner'
 import dayOverlapRefiner from './refiners/dayOverlapRefiner'
 
-const parser = new chrono.Chrono()
+const parser = new chrono.Chrono(chrono.options.casualOption())
 parser.parsers.push(militaryParser)
 parser.refiners.push(impliedAMEndRefiner)
 parser.refiners.push(impliedPMStartRefiner)

--- a/src/test/entry.test.js
+++ b/src/test/entry.test.js
@@ -97,8 +97,8 @@ test('includes yesterday in message', t => {
   const yesterday = moment().subtract(1, 'day')
   const e = new Entry('yesterday 4-5pm worked on some things #test')
 
-  t.ok(yesterday.isSame(e.start), 'sets start to yesterday')
-  t.ok(yesterday.isSame(e.end), 'sets end to yesterday')
+  t.ok(yesterday.isSame(e.start, 'day'), 'sets start to yesterday')
+  t.ok(yesterday.isSame(e.end, 'day'), 'sets end to yesterday')
   t.equals(e.time, 'yesterday 4-5pm', 'time component includes \'yesterday\'')
 
   t.end()

--- a/src/test/entry.test.js
+++ b/src/test/entry.test.js
@@ -104,6 +104,17 @@ test('includes yesterday in message', t => {
   t.end()
 })
 
+test('specific day in message', t => {
+  const date = new Date(2016, 2, 24) // Thurs, March 24
+  const monday = moment(new Date(2016, 2, 21)) // Mon, March 21
+  const e = new Entry('monday 4-5pm worked on some things #test', {date})
+
+  t.ok(monday.isSame(e.start, 'day'), 'start is monday')
+  t.ok(monday.isSame(e.end, 'day'), 'end is monday')
+
+  t.end()
+})
+
 test('constructor assigns _id', t => {
   const e = new Entry('8am-10am worked on some things')
 

--- a/src/test/entry.test.js
+++ b/src/test/entry.test.js
@@ -93,6 +93,17 @@ test('duration set for 11pm-2am', t => {
   t.end()
 })
 
+test('includes yesterday in message', t => {
+  const yesterday = moment().subtract(1, 'day')
+  const e = new Entry('yesterday 4-5pm worked on some things #test')
+
+  t.ok(yesterday.isSame(e.start), 'sets start to yesterday')
+  t.ok(yesterday.isSame(e.end), 'sets end to yesterday')
+  t.equals(e.time, 'yesterday 4-5pm', 'time component includes \'yesterday\'')
+
+  t.end()
+})
+
 test('constructor assigns _id', t => {
   const e = new Entry('8am-10am worked on some things')
 

--- a/src/test/entry.test.js
+++ b/src/test/entry.test.js
@@ -120,8 +120,8 @@ test('specific date in message', t => {
   const mar15 = moment(new Date(2016, 2, 15)) // Mon, March 21
   const e = new Entry('Mar 15 4-5pm worked on some things #test', {date})
 
-  t.ok(monday.isSame(e.start, 'day'), 'start is mar 15')
-  t.ok(monday.isSame(e.end, 'day'), 'end is mar 15')
+  t.ok(mar15.isSame(e.start, 'day'), 'start is mar 15')
+  t.ok(mar15.isSame(e.end, 'day'), 'end is mar 15')
 
   t.end()
 })

--- a/src/test/entry.test.js
+++ b/src/test/entry.test.js
@@ -104,13 +104,24 @@ test('includes yesterday in message', t => {
   t.end()
 })
 
-test('specific day in message', t => {
+test('specific day of week in message', t => {
   const date = new Date(2016, 2, 24) // Thurs, March 24
   const monday = moment(new Date(2016, 2, 21)) // Mon, March 21
   const e = new Entry('monday 4-5pm worked on some things #test', {date})
 
   t.ok(monday.isSame(e.start, 'day'), 'start is monday')
   t.ok(monday.isSame(e.end, 'day'), 'end is monday')
+
+  t.end()
+})
+
+test('specific date in message', t => {
+  const date = new Date(2016, 2, 24) // Thurs, March 24
+  const mar15 = moment(new Date(2016, 2, 15)) // Mon, March 21
+  const e = new Entry('Mar 15 4-5pm worked on some things #test', {date})
+
+  t.ok(monday.isSame(e.start, 'day'), 'start is mar 15')
+  t.ok(monday.isSame(e.end, 'day'), 'end is mar 15')
 
   t.end()
 })


### PR DESCRIPTION
E.g. you can now type `tick log "yesterday 4-5pm planning meeting"`

Fixes #151 