### PR TITLE
[breaking] use git inspired command names

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,17 +24,17 @@ tick commit "Jan 1 12am-1am partied!" # records time for Jan 1
 tick commit "12pm-1pm great #lunch at Mervo's" # add #tags anywhere
 ```
 
-### `tick list` 
+### `tick log` 
 
 display time entries
 
 ```shell
-tick list # shows you all your time entries for the past week
-tick list -d "jan1-31" # shows you time entries for Jan 1-31
-tick list -d2 # shows you time entries for the past 2 days (not including today - so 3 days)
-tick list -d0 # shows you time entries for today
-tick list -t lunch # list entries tagged with #lunch
-tick list -t dev design # list entries tagged with #dev AND #design
+tick log # shows you all your time entries for the past week
+tick log -d "jan1-31" # shows you time entries for Jan 1-31
+tick log -d2 # shows you time entries for the past 2 days (not including today - so 3 days)
+tick log -d0 # shows you time entries for today
+tick log -t lunch # display entries tagged with #lunch
+tick log -t dev design # display entries tagged with #dev AND #design
 ```
 
 ### `tick rm` 

--- a/README.md
+++ b/README.md
@@ -13,15 +13,15 @@ Use natural language and simple text based interfaces to track time on projects.
 
 ## Usage
 
-### `tick log` 
+### `tick commit` 
 
-logs time entries
+commits time entries
 
 ```shell
-tick log "8am-12pm fixed a bunch of bugs" # logs time entry for today
-tick log "9pm-11pm yesterday late night code jamming" # log time entry for yesterday
-tick log "Jan 1 12am-1am partied!" # log time for Jan 1
-tick log "12pm-1pm great #lunch at Mervo's" # add #tags anywhere
+tick commit "8am-12pm fixed a bunch of bugs" # records time for today
+tick commit "yesterday 9pm-11pm late night code" # records time for yesterday
+tick commit "Jan 1 12am-1am partied!" # records time for Jan 1
+tick commit "12pm-1pm great #lunch at Mervo's" # add #tags anywhere
 ```
 
 ### `tick list` 

--- a/src/commands/tick-commit.js
+++ b/src/commands/tick-commit.js
@@ -4,14 +4,14 @@ import { writeSaved } from './output'
 import createEntry from '../create'
 import db from '../db'
 
-export default log
+export default commit
 
-function log (yargs) {
+function commit (yargs) {
   let argv = yargs
-  .usage('Usage: tick log [options] [message]')
-  .example('tick log "8am-12pm fixing bugs #tickbin"', 'log work for current day')
-  .example('tick log "Jan 22 11am-1pm fixing bugs #tickbin"', 'log work for Jan 22')
-  .example('tick log "yesterday 4-5pm learning javascript #dev"', 'log work for yesterday')
+  .usage('Usage: tick commit [options] [message]')
+  .example('tick commit "8am-12pm fixing bugs #tickbin"', 'record work for current day')
+  .example('tick commit "Jan 22 11am-1pm fixing bugs #tickbin"', 'record work for Jan 22')
+  .example('tick commit "yesterday 4-5pm learning javascript #dev"', 'record work for yesterday')
   .help('h')
   .alias('h', 'help')
   .argv

--- a/src/commands/tick-log.js
+++ b/src/commands/tick-log.js
@@ -1,4 +1,4 @@
-export default list
+export default log
 
 import Entry from '../entry'
 import {getOutputs} from './output'
@@ -12,11 +12,11 @@ import { parseDateRange } from '../query'
 import Query from '../query'
 import csvStringify from 'csv-stringify'
 
-function list (yargs) {
+function log (yargs) {
   let argv = yargs
-  .usage('Usage: tick list [options]')
-  .example('tick list -t sometag -d "Jan 1-31"')
-  .example('tick list -d "Jan 1-15" -f csv')
+  .usage('Usage: tick log [options]')
+  .example('tick log -t sometag -d "Jan 1-31"')
+  .example('tick log -d "Jan 1-15" -f csv')
   .option('t', {
     alias: 'tag',
     describe: 'tags to filter as boolean AND (no # symbol - e.g. -t tag1 tag2)',
@@ -24,7 +24,7 @@ function list (yargs) {
   })
   .option('d', {
     alias: 'date',
-    describe: 'date range to filter entries or number of days to list',
+    describe: 'date range to filter entries or number of days to display',
     type: 'string'
   })
   .option('f', {

--- a/src/tick.js
+++ b/src/tick.js
@@ -2,7 +2,7 @@
 
 import yargs    from 'yargs'
 import manifest from '../package.json'
-import log      from './commands/tick-log'
+import commit   from './commands/tick-commit'
 import login    from './commands/tick-login'
 import list     from './commands/tick-list'
 import register from './commands/tick-register'
@@ -12,7 +12,7 @@ import sync     from './commands/tick-sync'
 
 yargs
 .usage('Usage: tick <command> [options]')
-.command('log', 'log a tick', log)
+.command('commit', 'commit a tick', commit)
 .command('login', 'login to your account', login)
 .command('list', 'list your ticks', list)
 .command('register', 'create an account', register)

--- a/src/tick.js
+++ b/src/tick.js
@@ -4,7 +4,7 @@ import yargs    from 'yargs'
 import manifest from '../package.json'
 import commit   from './commands/tick-commit'
 import login    from './commands/tick-login'
-import list     from './commands/tick-list'
+import log      from './commands/tick-log'
 import register from './commands/tick-register'
 import rm       from './commands/tick-rm'
 import upgrade  from './commands/tick-upgrade'
@@ -14,7 +14,7 @@ yargs
 .usage('Usage: tick <command> [options]')
 .command('commit', 'commit a tick', commit)
 .command('login', 'login to your account', login)
-.command('list', 'list your ticks', list)
+.command('log', 'display a log of your ticks', log)
 .command('register', 'create an account', register)
 .command('rm', 'delete a tick', rm)
 .command('upgrade', 'upgrade your tickbin', upgrade)


### PR DESCRIPTION
This breaking change changes the commands to be more familiar to user of git

* `tick commit` creates time entries (formerly `tick log`)
* `tick log` displays your time entries (formerly `tick list`)

Fixes #150 