### PR TITLE
add ref field to entry

### DIFF
--- a/src/entry.js
+++ b/src/entry.js
@@ -4,7 +4,7 @@ import moment from 'moment'
 import parser from './parser'
 
 export const hashPattern = /(#\w+[\w-]*)/g
-export const version = 3
+export const version = 4
 export default class Entry {
   constructor(message, opts = {}) {
     let {
@@ -17,6 +17,7 @@ export default class Entry {
     this.version = version
     this._id = shortid.generate()
     this.message = message
+    this.ref = date
     this.parse(message, date)
     this.parseTags(message)
   }
@@ -61,6 +62,7 @@ export default class Entry {
     return {
       _id: this._id,
       version: this.version,
+      ref: this.ref,
       message: this.message,
       hasDates: this.hasDates,
       start: this.start,

--- a/src/test/entry.test.js
+++ b/src/test/entry.test.js
@@ -90,7 +90,6 @@ test('passed reference date added to entry', t => {
   t.end()
 })
 
-
 test('duration set for 8am-10am', t => {
   const e = new Entry('8am-10am worked on some things')
   
@@ -222,6 +221,7 @@ test('fromJSON() will create an Entry from existing document', t => {
   t.equals(e.tags.size, 2, '2 tags')
   t.equals(moment(existing.start).toString(), moment(e.start).toString(), 'start matches')
   t.equals(moment(existing.end).toString(), moment(e.end).toString(), 'end matches')
+  t.equals(moment(existing.ref).toString(), moment(e.ref).toString(), 'ref matches')
   t.equals(e.time, '8am-10am', 'time is preserved')
 
   t.end()

--- a/src/test/entry.test.js
+++ b/src/test/entry.test.js
@@ -66,6 +66,18 @@ test('no date defaults to today', t => {
   t.end()
 })
 
+test('created date added to entry', t => {
+  const today = new Date()  
+  const e = new Entry('8am-5pm working on things')
+  const json = e.toJSON()
+
+  t.ok(e.ref, 'ref is set')
+  t.ok(moment(today).isSame(e.ref, 'second'), 'ref date is today')
+  t.ok(moment(today).isSame(json.ref, 'second'), 'json.ref date is today')
+  t.end()
+})
+
+
 test('duration set for 8am-10am', t => {
   const e = new Entry('8am-10am worked on some things')
   

--- a/src/test/entry.test.js
+++ b/src/test/entry.test.js
@@ -73,7 +73,20 @@ test('created date added to entry', t => {
 
   t.ok(e.ref, 'ref is set')
   t.ok(moment(today).isSame(e.ref, 'second'), 'ref date is today')
+  t.ok(json.ref, 'ref is set on json')
   t.ok(moment(today).isSame(json.ref, 'second'), 'json.ref date is today')
+  t.end()
+})
+
+test('passed reference date added to entry', t => {
+  const date = new Date(2016, 0, 1, 12, 15, 30) // Jan 1, 2016 12:15:30
+  const e = new Entry('8am-5pm working on things', {date})
+  const json = e.toJSON()
+
+  t.ok(e.ref, 'ref is set')
+  t.ok(moment(date).isSame(e.ref, 'second'), 'ref date is Jan 1')
+  t.ok(json.ref, 'ref is set on json')
+  t.ok(moment(date).isSame(json.ref, 'second'), 'json.ref date is Jan 1')
   t.end()
 })
 

--- a/src/test/upgrade.test.js
+++ b/src/test/upgrade.test.js
@@ -5,6 +5,7 @@ import promised from 'sinon-as-promised'
 import { map0to1 } from '../upgrade'
 import { map1to2 } from '../upgrade'
 import { map2to3 } from '../upgrade'
+import { map3to4 } from '../upgrade'
 import upgrade from '../upgrade'
 
 var rows = [
@@ -83,6 +84,19 @@ test('map2to3', t => {
   t.equals(v3.startArr, v2.fromArr, 'fromArr was changed to startArr')
   t.equals(v3.end, v2.to, 'to was changed to end')
   t.equals(v3.endArr, v2.toArr, 'toArr was changed to endArr')
+
+  t.end()
+})
+
+test('map3to4', t => {
+  const v3 = {
+    start: new Date(2016, 0, 1, 12, 0, 0, 0),
+  }
+
+  const v4 = map3to4(v3)
+
+  t.equals(v4.version, 4, 'sets version to 4')
+  t.equals(v4.ref.toString(), v3.start.toString(), 'ref is set to start')
 
   t.end()
 })

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -5,6 +5,7 @@ import _ from 'lodash'
 export { map0to1 }
 export { map1to2 }
 export { map2to3 }
+export { map3to4 }
 
 export default upgrade
 
@@ -22,6 +23,7 @@ function upgrade (db, start = 0, end = 2) {
       .map(map0to1)
       .map(map1to2)
       .map(map2to3)
+      .map(map3to4)
       .value()
     return db.bulkDocs(newDocs)
   })
@@ -73,6 +75,19 @@ function map2to3 (doc) {
   newDoc.end      = doc.to
   newDoc.endArr   = doc.toArr
   newDoc.version  = 3
+
+  return newDoc
+}
+
+function map3to4 (doc) {
+  if (doc.version >= 4)
+    return doc
+
+  let newDoc = {}
+  Object.assign(newDoc, doc)
+
+  newDoc.ref = moment(doc.start).toDate()
+  newDoc.version = 4
 
   return newDoc
 }


### PR DESCRIPTION
This is necessary to support editing of entries now that we have relative date support in the message (see #151)

This is a requirement of #8 