### PR TITLE
use sourcemaps

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,6 @@
     "transform-es2015-destructuring",
     "transform-es2015-parameters",
     "transform-es2015-spread"
-  ],
-  "sourceMaps": "inline"
+  ]
 }
 

--- a/.babelrc
+++ b/.babelrc
@@ -4,6 +4,7 @@
     "transform-es2015-destructuring",
     "transform-es2015-parameters",
     "transform-es2015-spread"
-  ]
+  ],
+  "sourceMaps": "inline"
 }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "clean": "rm -rf build/*",
     "build": "babel src --out-dir build/",
     "watch": "babel src --watch --out-dir build/",
-    "test": "tape 'build/test/**/*.js' | tap-spec",
+    "test": "tape -r source-map-support/register 'build/test/**/*.js' | tap-spec",
     "lint": "eslint 'src/**/*.js'",
     "prebuild": "npm run clean",
     "prewatch": "npm run clean"
@@ -36,6 +36,7 @@
     "nock": "^8.0.0",
     "sinon": "^1.17.3",
     "sinon-as-promised": "^4.0.0",
+    "source-map-support": "^0.4.0",
     "tap-spec": "^4.1.0",
     "tape": "^4.5.1"
   },

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   "preferGlobal": true,
   "scripts": {
     "clean": "rm -rf build/*",
-    "build": "babel src --out-dir build/",
-    "watch": "babel src --watch --out-dir build/",
+    "build": "babel src --source-maps --out-dir build/",
+    "watch": "babel src --source-maps --watch --out-dir build/",
     "test": "tape -r source-map-support/register 'build/test/**/*.js' | tap-spec",
     "lint": "eslint 'src/**/*.js'",
     "prebuild": "npm run clean",


### PR DESCRIPTION
This sets up sourcemaps (included as an inlined `//# sourceMappingURL` at the end of each file). This works great, but it does introduce inlined sourcemaps to each built file. I'm not sure if this is a bad thing or not.

I'm not yet sure quite how to generate separate source map files and then link them. At worst we could just run a comment remover/minifier to remove the comment and `sourceMappingUrl`.

Should we try to get them separate? Leave them inline? Remove them on publish?

It might be useful to have the sourcemap inline so that if an error is found by a user, the stack trace would be a bit more useful.

Thoughts @tickbin/core?