### PR TITLE
Support canceled prompts (commit, register)

### DIFF
--- a/src/commands/tick-commit.js
+++ b/src/commands/tick-commit.js
@@ -29,10 +29,8 @@ function commit(argv) {
       if (err && err.message === 'canceled')
         return console.log('\nCanceled. Nothing to save.')
 
-      if (err) {
+      if (err) 
         throw err
-        return
-      }
 
       createEntry(db, res.message)
       .then(writeSaved)

--- a/src/commands/tick-commit.js
+++ b/src/commands/tick-commit.js
@@ -25,11 +25,17 @@ function commit(argv) {
     prompt.message = ''
     prompt.delimiter = ''
     prompt.start()
-    prompt.get('message', function(err, res) {
-      if (!err){
-        createEntry(db, res.message)
-        .then(writeSaved)
+    prompt.get('message', (err, res) => {
+      if (err && err.message === 'canceled')
+        return console.log('\nCanceled. Nothing to save.')
+
+      if (err) {
+        throw err
+        return
       }
+
+      createEntry(db, res.message)
+      .then(writeSaved)
     })
   } else {
     createEntry(db, message)

--- a/src/commands/tick-login.js
+++ b/src/commands/tick-login.js
@@ -22,7 +22,12 @@ function login(argv) {
   prompt.start()
 
   prompt.get(values, (err, user) => {
-    if (err) throw err
+    if (err && err.message === 'canceled')
+      return console.log('\nCanceled login.')
+
+    if (err) 
+      throw err
+    
     server.login(user)
     .then(user => setConfig('remote', user.couch.url))
     .then(() => console.log('You\'re logged in now'))

--- a/src/commands/tick-register.js
+++ b/src/commands/tick-register.js
@@ -27,10 +27,9 @@ function register(yargs) {
     if (err && err.message === 'canceled')
       return console.log('\nNo? Ok, no hard feelings.') 
 
-    if (err) {
+    if (err)
       throw err
-      return
-    }
+    
 
     server.register(user)
     .then(user => setConfig('remote', user.couch.url))

--- a/src/commands/tick-register.js
+++ b/src/commands/tick-register.js
@@ -24,10 +24,12 @@ function register(yargs) {
   prompt.start()
 
   prompt.get(values, (err, user) => {
-    if (err.message === 'canceled') {
+    if (err && err.message === 'canceled')
       return console.log('\nNo? Ok, no hard feelings.') 
-    } else {
+
+    if (err) {
       throw err
+      return
     }
 
     server.register(user)

--- a/src/commands/tick-register.js
+++ b/src/commands/tick-register.js
@@ -24,7 +24,12 @@ function register(yargs) {
   prompt.start()
 
   prompt.get(values, (err, user) => {
-    if (err) throw err
+    if (err.message === 'canceled') {
+      return console.log('\nNo? Ok, no hard feelings.') 
+    } else {
+      throw err
+    }
+
     server.register(user)
     .then(user => setConfig('remote', user.couch.url))
     .then(() => console.log(chalk.bgGreen('Account created')))


### PR DESCRIPTION
Hitting `ctrl+c` causes prompt to return an error with message `canceled`. `tick register`, `tick login`, and `tick commit` (in prompt mode) now check for this and display friendly message.

Fixes #133 