### PR TITLE
Misc README fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,6 @@ To build the application:
 $ npm install
 $ npm run build
 $ ./build/tick --help
+```
 
 Copyright (C) 2016 MemoryLeaf Media Inc.
-```

--- a/README.md
+++ b/README.md
@@ -121,4 +121,4 @@ $ npm run build
 $ ./build/tick --help
 ```
 
-Copyright (C) 2016 MemoryLeaf Media Inc.
+Copyright (©) 2016 MemoryLeaf Media Inc.

--- a/README.md
+++ b/README.md
@@ -116,7 +116,6 @@ Run `tick sync` in order to sync your database with your remote server.
 To build the application:
 
 ```bash
-# Using node v4.2 or greater
 $ npm install
 $ npm run build
 $ ./build/tick --help


### PR DESCRIPTION
I noticed a couple things in the README:

* Our copyright header was inside the code block for building the application, I'm assuming we meant to have this at the end of the document
* We warn that 4.2 is required twice in the document, I updated it to only be at the top since specifying that we require 4.2 to run probably implies we also need it to build