### PR TITLE
use +/- symbol for saved/removed indicators

### DIFF
--- a/src/commands/output.js
+++ b/src/commands/output.js
@@ -12,13 +12,13 @@ export {getOutputs as getOutputs}
 function writeSaved (doc) {
   const entry = Entry.fromJSON(doc)
   const { detailed } = getOutputs(entry)
-  console.log(chalk.bgGreen('saved'), detailed)
+  console.log(chalk.bgGreen('+'), detailed)
 }
 
 function writeRemove (doc) {
   const entry = Entry.fromJSON(doc)
   const { detailed } = getOutputs(entry)
-  console.log(chalk.bgRed('removed'), detailed)
+  console.log(chalk.bgRed('-'), detailed)
 }
 
 function getOutputs(entry) {
@@ -35,9 +35,10 @@ function getOutputs(entry) {
     .replace(timePattern, ' ')
     .trim()
   const tags = chalk.cyan([...entry.tags].join(' '))
+  const icon = chalk.gray(' ') // TODO: make this reflect sync state
 
   const detailed = `${pad(id, 9)} ${pad(date, 9)} ${time} ${duration} ${msg}`
   const simple = `${pad(id, 9)} ${time} ${duration} ${msg}`
 
-  return {id, date, seconds, msg, tags, detailed, simple}
+  return {id, date, seconds, msg, tags, icon, detailed, simple}
 }

--- a/src/commands/output.js
+++ b/src/commands/output.js
@@ -28,7 +28,7 @@ function getOutputs(entry) {
   const timeStart = moment(entry.start)
   const timeEnd = moment(entry.end)
   const time = `${timeStart.format('hh:mma')}-${timeEnd.format('hh:mma')}`
-  const duration = chalk.green(format(entry.duration.minutes))
+  const duration = format(entry.duration.minutes)
   const seconds = entry.duration.seconds
   const msg = entry.message
     .replace(hashPattern, chalk.cyan('$1'))

--- a/src/commands/tick-log.js
+++ b/src/commands/tick-log.js
@@ -95,5 +95,5 @@ function writeEntryGroup(group) {
   const date = moment(group.date).format('ddd, MMM DD, YYYY')
   const duration = format(group.minutes)
   console.log(`${chalk.yellow(date)} ${chalk.green(duration)}`)
-  group.ticks.forEach(t => { console.log(getOutputs(t).simple) })
+  group.ticks.forEach(t => { console.log(`${getOutputs(t).icon} ${getOutputs(t).simple}`) })
 }

--- a/src/commands/tick-log.js
+++ b/src/commands/tick-log.js
@@ -94,6 +94,6 @@ function writeDefaultMessage(arr) {
 function writeEntryGroup(group) {
   const date = moment(group.date).format('ddd, MMM DD, YYYY')
   const duration = format(group.minutes)
-  console.log(`${chalk.yellow(date)} ${chalk.green(duration)}`)
+  console.log(`${chalk.yellow(date)} ${duration}`)
   group.ticks.forEach(t => { console.log(`${getOutputs(t).icon} ${getOutputs(t).simple}`) })
 }

--- a/src/time.js
+++ b/src/time.js
@@ -1,9 +1,12 @@
 export default format
 import pad from 'pad'
+import chalk from 'chalk'
 
 function format (minutes) {
-  const hours = Math.floor(minutes / 60)
-  const mins = minutes % 60
+  const hours = chalk.green(pad(2, Math.floor(minutes / 60)))
+  const mins = chalk.green(pad(2, minutes % 60))
 
-  return `${pad(2, hours)}h ${pad(2, mins)}m`
+  const h = chalk.green('h')
+  const m = chalk.green('m')
+  return `${hours}${h}${mins}${m}`
 }


### PR DESCRIPTION
also, clean up display colour code for better readability and removes a space from the duration display.

![tickbin zsh 2016-04-20 09-00-25](https://cloud.githubusercontent.com/assets/349600/14681527/55696e40-06d6-11e6-8bcc-f841e1b10dc7.jpg)


![tickbin zsh 2016-04-20 08-59-55](https://cloud.githubusercontent.com/assets/349600/14681517/47b43316-06d6-11e6-8274-d5bb1b8602d5.jpg)

Fixes #33 
