### PR TITLE
breaking: complex filtering by tags and dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,13 @@ display time entries
 ```shell
 tick log # shows you all your time entries for the past week
 tick log -d "jan1-31" # shows you time entries for Jan 1-31
+tick log -d "jan - feb" # shows you time entries for Jan 1-Feb 28
 tick log -d2 # shows you time entries for the past 2 days (not including today - so 3 days)
 tick log -d0 # shows you time entries for today
-tick log -t lunch # display entries tagged with #lunch
-tick log -t dev design # display entries tagged with #dev AND #design
+tick log -f "#lunch" # display entries tagged with #lunch
+tick log -f "#dev and #bug" # display entries tagged with #dev AND #bug
+tick log -f "#dev or #design" # display entries tagged with #dev or #design
+tick log -f "#dev and not #nobill" # display entries tagged with #dev but not #nobill
 ```
 
 ### `tick rm` 

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "axios": "^0.9.0",
     "chalk": "^1.1.3",
     "chrono-node": "^1.2.1",
+    "chrono-refiner-wholemonth": "0.0.4",
     "csv-stringify": "^1.0.2",
     "duration": "^0.2.0",
     "es6-error": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "prompt": "^1.0.0",
     "rc": "^1.1.1",
     "shortid": "^2.2.6",
+    "tickbin-filter-parser": "0.0.1",
     "untildify": "^2.1.0",
     "yargs": "^4.6.0"
   },

--- a/src/commands/tick-log.js
+++ b/src/commands/tick-log.js
@@ -37,7 +37,7 @@ function builder(yargs) {
   })
   .option('f', {
     alias: 'filter',
-    describe: 'filter entries (e.g. #tag1 and #tag2 and May - Apr)',
+    describe: 'filter entries (e.g. #tag1 and #tag2)',
     type: 'string'
   })
 }

--- a/src/commands/tick-log.js
+++ b/src/commands/tick-log.js
@@ -44,7 +44,7 @@ function log(argv) {
   start = moment(start).toArray()
   end = moment(end).toArray()
   const filter = argv.filter ? compileFilter(argv.filter) : null 
-  const opts = filter ? { filter } : { start, end, tags: argv.tag }
+  const opts = { start, end, filter }
 
   const query = new Query(db).findEntries(opts)
 

--- a/src/commands/tick-log.js
+++ b/src/commands/tick-log.js
@@ -16,13 +16,10 @@ export default { builder, handler : log }
 function builder(yargs) {
   return yargs
   .usage('Usage: tick log [options]')
-  .example('tick log -t sometag -d "Jan 1-31"')
+  .example('tick log -f "#tag1 and #tag2" -d "Jan 1-31"')
+  .example('tick log -f "#tag1 or #tag2" -d "Jan - Feb"')
+  .example('tick log -f "#tag1 and not #tag2" -d "Jan - Feb"')
   .example('tick log -d "Jan 1-15" -f csv')
-  //.option('t', {
-    //alias: 'tag',
-    //describe: 'tags to filter as boolean AND (no # symbol - e.g. -t tag1 tag2)',
-    //type: 'array'
-  //})
   .option('d', {
     alias: 'date',
     describe: 'date range to filter entries or number of days to display',

--- a/src/commands/tick-log.js
+++ b/src/commands/tick-log.js
@@ -17,21 +17,21 @@ function builder(yargs) {
   .usage('Usage: tick log [options]')
   .example('tick log -t sometag -d "Jan 1-31"')
   .example('tick log -d "Jan 1-15" -f csv')
-  .option('t', {
-    alias: 'tag',
-    describe: 'tags to filter as boolean AND (no # symbol - e.g. -t tag1 tag2)',
-    type: 'array'
-  })
+  //.option('t', {
+    //alias: 'tag',
+    //describe: 'tags to filter as boolean AND (no # symbol - e.g. -t tag1 tag2)',
+    //type: 'array'
+  //})
   .option('d', {
     alias: 'date',
     describe: 'date range to filter entries or number of days to display',
     type: 'string'
   })
-  .option('f', {
-    alias: 'format',
-    describe: 'format to display data in',
-    choices: ['csv', 'group', 'json'],
-    default: 'group',
+  .option('t', {
+    alias: 'type',
+    describe: 'type to display data in',
+    choices: ['csv', 'json', 'text'],
+    default: 'text',
     type: 'string'
   })
 }
@@ -43,7 +43,7 @@ function log(argv) {
 
   const query = new Query(db).findEntries({ start, end, tags: argv.tag })
 
-  switch (argv.format) {
+  switch (argv.type) {
     case 'csv':
       query.exec()
         .then(writeCSV)
@@ -53,7 +53,7 @@ function log(argv) {
       query.exec()
         .then(writeJSON)
       break
-    case 'group':
+    case 'text':
     default:
       query.groupByDate()
         .exec()

--- a/src/commands/tick-log.js
+++ b/src/commands/tick-log.js
@@ -9,6 +9,7 @@ import db from '../db'
 import { parseDateRange } from '../query'
 import Query from '../query'
 import csvStringify from 'csv-stringify'
+import compileFilter from 'tickbin-filter-parser'
 
 export default { builder, handler : log }
 
@@ -34,14 +35,21 @@ function builder(yargs) {
     default: 'text',
     type: 'string'
   })
+  .option('f', {
+    alias: 'filter',
+    describe: 'filter entries (e.g. #tag1 and #tag2 and May - Apr)',
+    type: 'string'
+  })
 }
 
 function log(argv) {
   let { start, end } = parseDateRange(argv.date)
   start = moment(start).toArray()
   end = moment(end).toArray()
+  const filter = argv.filter ? compileFilter(argv.filter) : null 
+  const opts = filter ? { filter } : { start, end, tags: argv.tag }
 
-  const query = new Query(db).findEntries({ start, end, tags: argv.tag })
+  const query = new Query(db).findEntries(opts)
 
   switch (argv.type) {
     case 'csv':

--- a/src/query.js
+++ b/src/query.js
@@ -31,7 +31,11 @@ export default class Query {
   /**
    * prepare query to find entries by date range filtered by tags
    */
-  findEntries ({start = null, end = null, tags = []} = {}) {
+  findEntries ({start = null, end = null, tags = [], filter = null} = {}) {
+    if ((start || end || tags.length >= 1) && filter) {
+      throw new Error(`You can not call findEntries with filter and 
+        (start or end or tags)`) 
+    } 
     this._queryOpts.descending = true
     this._queryOpts.startkey = end
     this._queryOpts.endkey = start

--- a/src/query.js
+++ b/src/query.js
@@ -32,18 +32,14 @@ export default class Query {
   /**
    * prepare query to find entries by date range filtered by tags
    */
-  findEntries ({start = null, end = null, tags = [], filter = null} = {}) {
-    if ((start || end || tags.length >= 1) && filter) {
-      throw new Error(`You can not call findEntries with filter and 
-        (start or end or tags)`) 
-    } 
+  findEntries ({start = null, end = null, filter = null} = {}) {
     this._queryOpts.descending = true
     if (end)
       this._queryOpts.startkey = end
     if (start)
       this._queryOpts.endkey = start
 
-    filter = filter || _.partial(filterTags, hashTags(tags))
+    filter = filter || function() { return true }
 
     this._chain = this._chain.filter(filter)
       .map(doc => Entry.fromJSON(doc))

--- a/src/query.js
+++ b/src/query.js
@@ -37,10 +37,14 @@ export default class Query {
         (start or end or tags)`) 
     } 
     this._queryOpts.descending = true
-    this._queryOpts.startkey = end
-    this._queryOpts.endkey = start
+    if (end)
+      this._queryOpts.startkey = end
+    if (start)
+      this._queryOpts.endkey = start
 
-    this._chain = this._chain.filter(_.partial(filterTags, hashTags(tags)))
+    filter = filter || _.partial(filterTags, hashTags(tags))
+
+    this._chain = this._chain.filter(filter)
       .map(doc => Entry.fromJSON(doc))
 
     return this 

--- a/src/query.js
+++ b/src/query.js
@@ -1,4 +1,5 @@
 import chrono from 'chrono-node'
+import wholeMonth from 'chrono-refiner-wholemonth'
 import moment from 'moment'
 import _ from 'lodash'
 import Entry from './entry'
@@ -120,9 +121,12 @@ function hashTags (tags = []) {
  * }
  */
 function parseDateRange (range) {
+  const parser = new chrono.Chrono()
+  parser.refiners.push(wholeMonth)
+
   let days = parseInt(range)
   days = days >= 0 ? days : 6 // default 6 days
-  let dates = chrono.parse(range)[0] || [{}]
+  let dates = parser.parse(range)[0] || [{}]
   // by default, set the date range then check if chrono parsed anything good
   let start = moment().subtract(days, 'days').startOf('day').toDate()
   let end   = moment().endOf('day').toDate()

--- a/src/test/query.test.js
+++ b/src/test/query.test.js
@@ -62,6 +62,31 @@ test('findEntries() prepares the query', t => {
   t.equals(qOpts.endkey, start, 'endkey is the start date')
 })
 
+test('findEntries() accepts filter OR start, end, tags', t => {
+  const q = new Query(getFakeDb)
+  const start = moment().startOf('day').toArray()
+  const end = moment().endOf('day').toArray()
+  const tags = ['a']
+  const filter = function() {}
+
+  function findEverything () {
+    q.findEntries({start, end, tags, filter}) 
+  }
+
+  function findFilterOnly () {
+    q.findEntries({filter}) 
+  }
+
+  function findStartEndTags () {
+    q.findEntries({start, end, tags}) 
+  }
+
+  t.plan(3)
+  t.throws(findEverything, 'do not call with start, end, tags AND filter')
+  t.doesNotThrow(findFilterOnly, 'you can call with just filter')
+  t.doesNotThrow(findStartEndTags, 'you can call with just start, end, tags')
+})
+
 test('exec() returns a promise', t => {
   const fakeDb = getFakeDb()
   const stub = sinon.stub(fakeDb, 'query').resolves(results)

--- a/src/test/query.test.js
+++ b/src/test/query.test.js
@@ -237,12 +237,22 @@ test('hashTags() prepends # to tags', t => {
 })
 
 test('parseDateRange() returns start and end date', t => {
-
   const { start, end } = parseDateRange('Jan 1-31')
 
   t.equals(start.getMonth(), 0, 'start month is Jan')
   t.equals(start.getDate(), 1, 'start day is 1')
   t.equals(end.getMonth(), 0, 'end month is Jan')
+  t.equals(end.getDate(), 31, 'end day is 31')
+
+  t.end()
+})
+
+test('parseDateRange() handles whole months', t => {
+  const { start, end } = parseDateRange('Apr - May')
+
+  t.equals(start.getMonth(), 3, 'start month is Apr')
+  t.equals(start.getDate(), 1, 'start day is 1')
+  t.equals(end.getMonth(), 4, 'end month is May')
   t.equals(end.getDate(), 31, 'end day is 31')
 
   t.end()

--- a/src/test/query.test.js
+++ b/src/test/query.test.js
@@ -174,22 +174,6 @@ test('findEntries().exec() filters by filter function', t => {
     })
 })
 
-test('findEntries().exec() filters by date function', t => {
-  const fakeDb = getFakeDb()
-  const stub = sinon.stub(fakeDb, 'query').resolves(results)
-  const filter = compileFilter('March 1 2015 - March 31 2015')
-
-  t.plan(2)
-  new Query(fakeDb)
-    .findEntries({filter})
-    .exec()
-    .then(entries => {
-      t.equals(entries.length, 1, 'there is only one entry in Mar 2015') 
-      t.equals(entries[0].message, '1pm-2pm work in March', 'check entry is from march')
-    })
-})
-
-
 test('findEntries().groupByDate().exec() returns expected entries', t => {
   const fakeDb = getFakeDb()
   const stub = sinon.stub(fakeDb, 'query').resolves(results)

--- a/src/test/query.test.js
+++ b/src/test/query.test.js
@@ -14,10 +14,14 @@ import compileFilter from 'tickbin-filter-parser'
 
 const today = moment().toDate()
 const yesterday = moment().subtract(1, 'day').toDate()
+const march = moment(new Date('2015-03-15')).toDate()
+const april = moment(new Date('2015-04-15')).toDate()
 const results = { rows:[
   { doc: new Entry('1pm-2pm work', { date: today }).toJSON()},
   { doc: new Entry('2pm-3pm work #tag', { date: today }).toJSON()},
-  { doc: new Entry('1pm-2pm work', { date: yesterday }).toJSON()}
+  { doc: new Entry('1pm-2pm work', { date: yesterday }).toJSON()},
+  { doc: new Entry('1pm-2pm work in March', { date: march }).toJSON()},
+  { doc: new Entry('1pm-2pm work in April', { date: april }).toJSON()}
 ]}
 
 function getFakeDb() {
@@ -129,12 +133,11 @@ test('findEntries().exec() returns array of entries', t => {
   const today = moment().startOf('day').toArray()
   const yesterday = moment().endOf('day').toArray()
 
-  t.plan(3)
+  t.plan(2)
   new Query(fakeDb)
     .findEntries({ start: today, end: yesterday })
     .exec()
     .then(entries => {
-      t.equals(entries.length, 3, 'should only return three') 
       t.equals(entries[0].message, '1pm-2pm work', 'entries are on the list')
       t.ok(entries[0].duration.from, 'docs are converted to entry objects')
     })
@@ -169,7 +172,21 @@ test('findEntries().exec() filters by filter function', t => {
       t.equals(entries.length, 1, 'there is only one entry tagged #tag') 
       t.equals(entries[0].message, '2pm-3pm work #tag', 'check entry is tagged')
     })
+})
 
+test('findEntries().exec() filters by date function', t => {
+  const fakeDb = getFakeDb()
+  const stub = sinon.stub(fakeDb, 'query').resolves(results)
+  const filter = compileFilter('March 1 2015 - March 31 2015')
+
+  t.plan(2)
+  new Query(fakeDb)
+    .findEntries({filter})
+    .exec()
+    .then(entries => {
+      t.equals(entries.length, 1, 'there is only one entry in Mar 2015') 
+      t.equals(entries[0].message, '1pm-2pm work in March', 'check entry is from march')
+    })
 })
 
 

--- a/src/test/query.test.js
+++ b/src/test/query.test.js
@@ -10,6 +10,7 @@ import { hashTags } from '../query'
 import { parseDateRange } from '../query'
 import { groupEntries } from '../query'
 import Query from '../query'
+import compileFilter from 'tickbin-filter-parser'
 
 const today = moment().toDate()
 const yesterday = moment().subtract(1, 'day').toDate()
@@ -154,6 +155,23 @@ test('findEntries().exec() filters by tag', t => {
       t.equals(entries[0].message, '2pm-3pm work #tag', 'check entry is tagged')
     })
 })
+
+test('findEntries().exec() filters by filter function', t => {
+  const fakeDb = getFakeDb()
+  const stub = sinon.stub(fakeDb, 'query').resolves(results)
+  const filter = compileFilter('#tag')
+
+  t.plan(2)
+  new Query(fakeDb)
+    .findEntries({filter})
+    .exec()
+    .then(entries => {
+      t.equals(entries.length, 1, 'there is only one entry tagged #tag') 
+      t.equals(entries[0].message, '2pm-3pm work #tag', 'check entry is tagged')
+    })
+
+})
+
 
 test('findEntries().groupByDate().exec() returns expected entries', t => {
   const fakeDb = getFakeDb()

--- a/src/test/query.test.js
+++ b/src/test/query.test.js
@@ -67,31 +67,6 @@ test('findEntries() prepares the query', t => {
   t.equals(qOpts.endkey, start, 'endkey is the start date')
 })
 
-test('findEntries() accepts filter OR start, end, tags', t => {
-  const q = new Query(getFakeDb)
-  const start = moment().startOf('day').toArray()
-  const end = moment().endOf('day').toArray()
-  const tags = ['a']
-  const filter = function() {}
-
-  function findEverything () {
-    q.findEntries({start, end, tags, filter}) 
-  }
-
-  function findFilterOnly () {
-    q.findEntries({filter}) 
-  }
-
-  function findStartEndTags () {
-    q.findEntries({start, end, tags}) 
-  }
-
-  t.plan(3)
-  t.throws(findEverything, 'do not call with start, end, tags AND filter')
-  t.doesNotThrow(findFilterOnly, 'you can call with just filter')
-  t.doesNotThrow(findStartEndTags, 'you can call with just start, end, tags')
-})
-
 test('exec() returns a promise', t => {
   const fakeDb = getFakeDb()
   const stub = sinon.stub(fakeDb, 'query').resolves(results)
@@ -140,22 +115,6 @@ test('findEntries().exec() returns array of entries', t => {
     .then(entries => {
       t.equals(entries[0].message, '1pm-2pm work', 'entries are on the list')
       t.ok(entries[0].duration.from, 'docs are converted to entry objects')
-    })
-})
-
-test('findEntries().exec() filters by tag', t => {
-  const fakeDb = getFakeDb()
-  const stub = sinon.stub(fakeDb, 'query').resolves(results)
-  const today = moment().startOf('day').toArray()
-  const yesterday = moment().endOf('day').toArray()
-
-  t.plan(2)
-  new Query(fakeDb)
-    .findEntries({ start: today, end: yesterday, tags: ['tag']})
-    .exec()
-    .then(entries => {
-      t.equals(entries.length, 1, 'there is only one entry tagged')
-      t.equals(entries[0].message, '2pm-3pm work #tag', 'check entry is tagged')
     })
 })
 


### PR DESCRIPTION
Addresses #179 

This change makes a few critical changes:

* `--tags`/`-t` has been removed in favour of `--filter`/`-f` which lets you supply a boolean logic based tag filter (e.g. "#tag1 and not #tag2")
* `--format`/`-f` has been changed to `--type`/`-t`
* `--type=group` is changed to `--type=text`
*`--date`/`-d` now supports whole month ranges (e.g. "May - Jun")

I've opted to keep the tags and dates separate for now due to the way couchdb queries work. The https://github.com/tickbin/filter-parser is a hacky library that generates a single filtering function. With couch we would need to query the entire dataset, return it, and then run the filter function on the result set in the client (slow!). Separating the dates from the tags allows the query to use the dates as startkey and endkey, limiting the number of records substantially.

This is working, but not the full featured `--filter` functionality desired. I'm working on a jison based parser that will generate CouchDB 2.0 compatible query selector objects which should improve the capabilities and speed.

I'm making this PR as a first step so that we have something that works well and will continue working on the query parser.

### Tasks

* [x] fix `query.findEntries` to allow `start`, `end`, `filter`