### PR TITLE
chore: start using standard-version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Change Log
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+<a name="0.3.2"></a>
+## [0.3.2](https://github.com/tickbin/tickbin/compare/v0.3.1...v0.3.2) (2016-06-19)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,37 @@
+
+## Building
+
+To build the application:
+
+    npm install
+    npm run build
+    ./build/tick --help #you could create an alias in your .bashrc
+
+## Testing
+
+Pull requests will not be merged in if tests do not pass. We use sempaphore as
+hosted CI tool, but you can run your tests locally too
+
+    npm test
+
+Please ensure that you test your code well using the style in the existing
+tests.
+
+## Making a pull request
+
+Please be descriptive in your PR descriptions and ensure that only one feature
+or fix is included in a PR. Use the [conventional changelog](https://github.com/conventional-changelog/standard-version#commit-message-convention-at-a-glance)
+standard for your pull request title and description.
+
+We will squash your commits.
+
+## Releasing
+
+Core developers will handle cutting and publishing of releases (which we will
+eventually automate). To do a release:
+
+    npm run release
+    npm push <upstream> master --tags
+    npm publish
+
+This will update the CHANGELOG with changes and set the correct version

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,28 @@ Please be descriptive in your PR descriptions and ensure that only one feature
 or fix is included in a PR. Use the [conventional changelog](https://github.com/conventional-changelog/standard-version#commit-message-convention-at-a-glance)
 standard for your pull request title and description.
 
-We will squash your commits.
+_patches:_
+
+    git commit -a -m "fix(parsing): fixed a bug in our parser"
+
+_features:_
+
+    git commit -a -m "feat(parser): we now have a parser \o/"
+
+_breaking changes:_
+
+    git commit -a -m "feat(new-parser): introduces a new parsing library
+    BREAKING CHANGE: new library does not support foo-construct"
+
+_other changes:_
+
+You decide, e.g., docs, chore, etc.
+
+    git commit -a -m "docs: fixed up the docs a bit"
+    git commit -a -m "chore"
+
+For a more detailed description of changelog conventions see
+https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md
 
 ## Releasing
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,23 +25,23 @@ standard for your pull request title and description.
 
 _patches:_
 
-    git commit -a -m "fix(parsing): fixed a bug in our parser"
+    "fix(parsing): fixed a bug in our parser"
 
 _features:_
 
-    git commit -a -m "feat(parser): we now have a parser \o/"
+    "feat(parser): we now have a parser \o/"
 
 _breaking changes:_
 
-    git commit -a -m "feat(new-parser): introduces a new parsing library
+    "feat(new-parser): introduces a new parsing library
     BREAKING CHANGE: new library does not support foo-construct"
 
 _other changes:_
 
 You decide, e.g., docs, chore, etc.
 
-    git commit -a -m "docs: fixed up the docs a bit"
-    git commit -a -m "chore"
+    "docs: fixed up the docs a bit"
+    "chore(package): update dependencies"
 
 For a more detailed description of changelog conventions see
 https://github.com/bcoe/conventional-changelog-standard/blob/master/convention.md

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Build Status](https://semaphoreci.com/api/v1/jonotron/tickbin/branches/master/shields_badge.svg)](https://semaphoreci.com/jonotron/tickbin)
 [![dependency stats](https://david-dm.org/tickbin/tickbin.svg)](https://david-dm.org/tickbin/tickbin)
+[![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
 
 # tickbin
 

--- a/README.md
+++ b/README.md
@@ -115,14 +115,4 @@ remote=http://user:pass@host:port/dbname
 
 Run `tick sync` in order to sync your database with your remote server.
 
-## Building
-
-To build the application:
-
-```bash
-$ npm install
-$ npm run build
-$ ./build/tick --help
-```
-
 Copyright (©) 2016 MemoryLeaf Media Inc.

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "watch": "babel src --source-maps --watch --out-dir build/",
     "test": "env TZ='Etc/UTC' tape -r source-map-support/register 'build/test/**/*.js' | tap-spec",
     "lint": "eslint 'src/**/*.js'",
+    "release": "standard-version",
+    "prepublish": "npm run build",
     "prebuild": "npm run clean",
     "prewatch": "npm run clean"
   },
@@ -37,6 +39,7 @@
     "sinon": "^1.17.3",
     "sinon-as-promised": "^4.0.0",
     "source-map-support": "^0.4.0",
+    "standard-version": "^2.3.1",
     "tap-spec": "^4.1.0",
     "tape": "^4.5.1"
   },


### PR DESCRIPTION
This better automates the release process with [standard-version](https://npmjs.org/standard-version).

Core devs can now simply run `npm run release` to cut a new release **and** generate an updated changelog.

Included a CONTRIBUTING.md guide with some info about how to structure PR titles.