### PR TITLE
feat(duration): create entries by duration

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ tick commit "8am-12pm fixed a bunch of bugs" # records time for today
 tick commit "yesterday 9pm-11pm late night code" # records time for yesterday
 tick commit "Jan 1 12am-1am partied!" # records time for Jan 1
 tick commit "12pm-1pm great #lunch at Mervo's" # add #tags anywhere
+tick commit "4 hours 15 minutes no specific time" # record durations without start/end
 ```
 
 ### `tick log` 

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prompt": "^1.0.0",
     "rc": "^1.1.1",
     "tickbin-filter-parser": "0.0.4",
-    "tickbin-parser": "^0.1.1",
+    "tickbin-parser": "^0.2.0",
     "untildify": "^3.0.2",
     "yargs": "^4.6.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tickbin",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "tickbin time tracking",
   "bin": {
     "tick": "./build/tick.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tickbin",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "tickbin time tracking",
   "bin": {
     "tick": "./build/tick.js"

--- a/src/commands/output.js
+++ b/src/commands/output.js
@@ -32,7 +32,9 @@ function getOutputs(entry) {
   const date = chalk.yellow(moment(entry.start).format('ddd MMM DD'))
   const timeStart = moment(entry.start)
   const timeEnd = moment(entry.end)
-  const time = `${timeStart.format('hh:mma')}-${timeEnd.format('hh:mma')}`
+  const time = entry.createdFrom === 'duration' ?
+    pad('', 15, '-') :
+    `${timeStart.format('hh:mma')}-${timeEnd.format('hh:mma')}`
   const duration = format(entry.duration.minutes)
   const seconds = entry.duration.seconds
   const msg = entry.message

--- a/src/commands/tick-commit.js
+++ b/src/commands/tick-commit.js
@@ -12,6 +12,7 @@ function builder(yargs) {
   .example('tick commit "8am-12pm fixing bugs #tickbin"', 'record work for current day')
   .example('tick commit "Jan 22 11am-1pm fixing bugs #tickbin"', 'record work for Jan 22')
   .example('tick commit "yesterday 4-5pm learning javascript #dev"', 'record work for yesterday')
+  .example('tick commit "4 hours 15 minutes no specific time"', 'record duration with no start/end')
 }
 
 function commit(argv) {

--- a/src/commands/tick-log.js
+++ b/src/commands/tick-log.js
@@ -49,22 +49,32 @@ function log(argv) {
   switch (argv.type) {
     case 'csv':
       query.exec()
+        .then(soryByRefDate)
         .then(writeCSV)
         .then(writeDefaultMessage)
       break
     case 'json':
       query.exec()
+        .then(sortByRefDate)
         .then(writeJSON)
       break
     case 'text':
     default:
       query.groupByDate()
         .exec()
+        .then(sortByRefDate)
         .then(group => writeGroup(group, argv.hideDetails, argv.hideSummary))
         .then(writeDefaultMessage)
         .catch(console.error)
       break
   }
+}
+
+function sortByRefDate(results) {
+  return results.map(group => {
+    group.ticks = _.sortBy(group.ticks, 'ref')
+    return group
+  })
 }
 
 function writeFilterError() {

--- a/src/commands/tick-log.js
+++ b/src/commands/tick-log.js
@@ -49,20 +49,20 @@ function log(argv) {
   switch (argv.type) {
     case 'csv':
       query.exec()
-        .then(soryByRefDate)
+        .then(sortByCreatedFrom)
         .then(writeCSV)
         .then(writeDefaultMessage)
       break
     case 'json':
       query.exec()
-        .then(sortByRefDate)
+        .then(sortByCreatedFrom)
         .then(writeJSON)
       break
     case 'text':
     default:
       query.groupByDate()
         .exec()
-        .then(sortByRefDate)
+        .then(sortByCreatedFrom)
         .then(group => writeGroup(group, argv.hideDetails, argv.hideSummary))
         .then(writeDefaultMessage)
         .catch(console.error)
@@ -70,9 +70,18 @@ function log(argv) {
   }
 }
 
-function sortByRefDate(results) {
+/*
+ * Ticks are already sorted by start. We need to move the duration type ticks
+ * to the top of the sorted list and order them by ref.
+ */
+function sortByCreatedFrom(results) {
   return results.map(group => {
-    group.ticks = _.sortBy(group.ticks, 'ref')
+    const durationTicks = _.chain(group.ticks)
+    .remove(['createdFrom', 'duration'])
+    .sortBy('ref')
+
+    group.ticks = [...durationTicks, ...group.ticks]
+
     return group
   })
 }

--- a/src/commands/tick-log.js
+++ b/src/commands/tick-log.js
@@ -62,7 +62,7 @@ function log(argv) {
     default:
       query.groupByDate()
         .exec()
-        .then(sortByCreatedFrom)
+        .then(sortGroupsByCreatedFrom)
         .then(group => writeGroup(group, argv.hideDetails, argv.hideSummary))
         .then(writeDefaultMessage)
         .catch(console.error)
@@ -74,13 +74,17 @@ function log(argv) {
  * Ticks are already sorted by start. We need to move the duration type ticks
  * to the top of the sorted list and order them by ref.
  */
-function sortByCreatedFrom(results) {
-  return results.map(group => {
-    const durationTicks = _.chain(group.ticks)
-    .remove(['createdFrom', 'duration'])
-    .sortBy('ref')
+function sortByCreatedFrom(ticks) {
+  const durationTicks = _.chain(ticks)
+  .remove(['createdFrom', 'duration'])
+  .sortBy('ref')
 
-    group.ticks = [...durationTicks, ...group.ticks]
+  return [...durationTicks, ...ticks]
+}
+
+function sortGroupsByCreatedFrom(results) {
+  return results.map(group => {
+    group.ticks = sortByCreatedFrom(group.ticks)
 
     return group
   })

--- a/src/test/upgrade.test.js
+++ b/src/test/upgrade.test.js
@@ -155,11 +155,29 @@ test('map5to6', t => {
 })
 
 test('map6to7', t => {
-  const v6 = {}
+  t.test('no createdFrom', t => {
+    const v6 = {}
 
-  const v7 = map6to7(v6)
+    const v7 = map6to7(v6)
 
-  t.equals(v7.createdFrom, 'calendar', 'sets createdFrom to calendar')
+    t.equals(v7.version , 7, 'sets verstion to 7')
+    t.equals(v7.createdFrom, 'calendar', 'sets createdFrom to calendar')
+
+    t.end()
+  })
+
+  t.test('existing createdFrom', t => {
+    const v6 = {
+      createdFrom: 'duration'
+    }
+
+    const v7 = map6to7(v6)
+
+    t.equals(v7.version , 7, 'sets verstion to 7')
+    t.equals(v7.createdFrom, 'duration', 'does not change createdFrom')
+
+    t.end()
+  })
 
   t.end()
 })

--- a/src/test/upgrade.test.js
+++ b/src/test/upgrade.test.js
@@ -8,6 +8,7 @@ import { map2to3 } from '../upgrade'
 import { map3to4 } from '../upgrade'
 import { map4to5 } from '../upgrade'
 import { map5to6 } from '../upgrade'
+import { map6to7 } from '../upgrade'
 import upgrade from '../upgrade'
 
 var docs = [
@@ -149,6 +150,16 @@ test('map5to6', t => {
   t.equals(v6.version, 6, 'sets version to 6')
   t.equals(v6.original, v5.message, 'saves original message')
   t.equals(v6.message, messageWithoutTime, 'saves message without time')
+
+  t.end()
+})
+
+test('map6to7', t => {
+  const v6 = {}
+
+  const v7 = map6to7(v6)
+
+  t.equals(v7.createdFrom, 'calendar', 'sets createdFrom to calendar')
 
   t.end()
 })

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -29,6 +29,7 @@ function upgrade (db, start = 0, end = 6) {
       .map(map3to4)
       .map(map4to5)
       .map(map5to6)
+      .map(map6to7)
       .value()
     return db.bulkDocs(newDocs)
   })
@@ -134,13 +135,12 @@ function map6to7 (doc) {
   if (doc.version >= 7)
     return doc
 
-  if (doc.createdFrom)
-    return doc
-
   let newDoc = {}
   Object.assign(newDoc, doc)
 
-  newDoc.createdFrom = 'calendar'
+  if (!doc.createdFrom)
+    newDoc.createdFrom = 'calendar'
+  newDoc.version = 7
 
   return newDoc
 }

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -8,10 +8,11 @@ export { map2to3 }
 export { map3to4 }
 export { map4to5 }
 export { map5to6 }
+export { map6to7 }
 
 export default upgrade
 
-function upgrade (db, start = 0, end = 5) {
+function upgrade (db, start = 0, end = 6) {
   if (!db) throw new Error('Please provide a couchdb instance')
 
   return db.find({
@@ -125,6 +126,21 @@ function map5to6 (doc) {
   .replace(timePattern, ' ')
   .trim()
   newDoc.version = 6
+
+  return newDoc
+}
+
+function map6to7 (doc) {
+  if (doc.version >= 7)
+    return doc
+
+  if (doc.createdFrom)
+    return doc
+
+  let newDoc = {}
+  Object.assign(newDoc, doc)
+
+  newDoc.createdFrom = 'calendar'
 
   return newDoc
 }


### PR DESCRIPTION
* Create entries using duration (`tick commit "1 hour 15 minutes did some #stuff"`)
* Entries now have a `createdFrom` field which tracks which method was used to create the entry. (ie calendar, duration, etc)

I still need to update the docs/help to show duration input, but can someone from @tickbin/core review this? Preferably pull down my branch and try to break it.