### PR TITLE
chore(tests): explicitly set year to ensure tests are deterministic 

### DIFF
--- a/src/test/query.test.js
+++ b/src/test/query.test.js
@@ -55,7 +55,7 @@ test('query functions are fluent', t => {
 
 test('findEntries() prepares the query', t => {
   const q = new Query(getFakeDb)
-  const filter = "#a May"
+  const filter = "#a May 2016"
   q.findEntries(filter)
   const qFind = q._find
   const selector = { '$and': [


### PR DESCRIPTION
This applies (via cherry-pick) bad4218a496752b8264440e846282da136a5b76b from https://github.com/tickbin/tickbin/pull/298 by @chadfawcett 