### PR TITLE
Fix missing message

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "prompt": "^1.0.0",
     "rc": "^1.1.1",
     "tickbin-filter-parser": "0.0.4",
-    "tickbin-parser": "^0.2.1",
+    "tickbin-parser": "^0.2.2",
     "untildify": "^3.0.2",
     "yargs": "^6.0.0"
   },

--- a/src/commands/tick-commit.js
+++ b/src/commands/tick-commit.js
@@ -13,12 +13,20 @@ function builder(yargs) {
   .example('tick commit "Jan 22 11am-1pm fixing bugs #tickbin"', 'record work for Jan 22')
   .example('tick commit "yesterday 4-5pm learning javascript #dev"', 'record work for yesterday')
   .example('tick commit "4 hours 15 minutes no specific time"', 'record duration with no start/end')
+  .option('m', {
+    alias: 'message',
+    describe: 'message for your time entry',
+    type: 'string'
+  })
 }
 
 function commit(argv) {
   let message
 
-  if (argv._[1]) {
+  if (argv.message)
+    message = argv.message
+
+  if (!message && argv._[1]) {
     message = argv._[1]
   }
 

--- a/src/test/query.test.js
+++ b/src/test/query.test.js
@@ -55,7 +55,7 @@ test('query functions are fluent', t => {
 
 test('findEntries() prepares the query', t => {
   const q = new Query(getFakeDb)
-  const filter = "#a May"
+  const filter = "#a May 2016"
   q.findEntries(filter)
   const qFind = q._find
   const selector = { '$and': [

--- a/src/test/upgrade.test.js
+++ b/src/test/upgrade.test.js
@@ -9,6 +9,7 @@ import { map3to4 } from '../upgrade'
 import { map4to5 } from '../upgrade'
 import { map5to6 } from '../upgrade'
 import { map6to7 } from '../upgrade'
+import { map7to8 } from '../upgrade'
 import upgrade from '../upgrade'
 
 var docs = [
@@ -173,11 +174,29 @@ test('map6to7', t => {
 
     const v7 = map6to7(v6)
 
-    t.equals(v7.version , 7, 'sets verstion to 7')
+    t.equals(v7.version , 7, 'sets version to 7')
     t.equals(v7.createdFrom, 'duration', 'does not change createdFrom')
 
     t.end()
   })
+
+  t.end()
+})
+
+test('map7to8', t => {
+  //  Malformed entry
+  const v7 = {
+    message: '',
+    time: '0945-1200 connection api end point to consumer #streamline',
+    original: '0945-1200 connection api end point to consumer #streamline'
+  }
+
+  const v8 = map7to8(v7)
+
+  t.equals(v8.version, 8, 'sets version to 8')
+  t.equals(v8.message, 'connection api end point to consumer #streamline', 'fixes message')
+  t.equals(v8.time, '0945-1200', 'fixes time')
+  t.equals(v8.original, v7.original, 'does not change original')
 
   t.end()
 })

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -9,6 +9,7 @@ export { map3to4 }
 export { map4to5 }
 export { map5to6 }
 export { map6to7 }
+export { map7to8 }
 
 export default upgrade
 
@@ -141,6 +142,26 @@ function map6to7 (doc) {
   if (!doc.createdFrom)
     newDoc.createdFrom = 'calendar'
   newDoc.version = 7
+
+  return newDoc
+}
+
+//  This fixes documents that were affected by a bug that would wipe their
+//  message when passed through map5to6.
+function map7to8 (doc) {
+  if (doc.version >= 8)
+    return doc
+
+  let newDoc = {}
+  Object.assign(newDoc, doc)
+
+  const tempDoc = new Entry(doc.user, doc.original)
+
+  console.log(tempDoc)
+
+  newDoc.time    = tempDoc.time
+  newDoc.message = tempDoc.message
+  newDoc.version = 8
 
   return newDoc
 }

--- a/src/upgrade.js
+++ b/src/upgrade.js
@@ -157,8 +157,6 @@ function map7to8 (doc) {
 
   const tempDoc = new Entry(doc.user, doc.original)
 
-  console.log(tempDoc)
-
   newDoc.time    = tempDoc.time
   newDoc.message = tempDoc.message
   newDoc.version = 8


### PR DESCRIPTION
Fixes documents that were affected by a bug that would wipe their message when passed through `map5to6`. There was a previous bug to this that set the `time` field on the entries to the whole message, which caused the `map5to6` function to function incorrectly. This only affected a small set of entries (seemed to be related to military time).