### PR TITLE
chore: update eslint, lodash, moment, yargs

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "babel-plugin-transform-es2015-modules-commonjs": "^6.7.4",
     "babel-plugin-transform-es2015-parameters": "^6.7.0",
     "babel-plugin-transform-es2015-spread": "^6.6.5",
-    "eslint": "3.10.0",
+    "eslint": "^3.10.1",
     "nock": "^9.0.0",
     "sinon": "^1.17.3",
     "sinon-as-promised": "^4.0.0",
@@ -51,9 +51,9 @@
     "ini": "^1.3.4",
     "jouch": "0.0.4",
     "lie": "^3.0.4",
-    "lodash": "^4.17.0",
+    "lodash": "^4.17.1",
     "mkdirp": "^0.5.1",
-    "moment": "^2.13.0",
+    "moment": "^2.16.0",
     "pad": "^1.0.0",
     "pouchdb": "^6.0.6",
     "pouchdb-find": "^0.10.2",
@@ -62,7 +62,7 @@
     "tickbin-filter-parser": "0.0.4",
     "tickbin-parser": "^0.2.2",
     "untildify": "^3.0.2",
-    "yargs": "^6.0.0"
+    "yargs": "^6.4.0"
   },
   "engines": {
     "node": "^4.2.0"


### PR DESCRIPTION
used `npm-check` to update the dependencies.