### PR TITLE
chore: update build badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://semaphoreci.com/api/v1/jonotron/tickbin/branches/master/shields_badge.svg)](https://semaphoreci.com/jonotron/tickbin)
+[![Build Status](https://semaphoreci.com/api/v1/twostoryrobot/tickbin/branches/master/badge.svg)](https://semaphoreci.com/twostoryrobot/tickbin)
 [![dependency stats](https://david-dm.org/tickbin/tickbin.svg)](https://david-dm.org/tickbin/tickbin)
 [![Standard Version](https://img.shields.io/badge/release-standard%20version-brightgreen.svg)](https://github.com/conventional-changelog/standard-version)
 


### PR DESCRIPTION
Now points to the two story robot organization semaphore account