### PR TITLE
Make incorrect username or password error message more clear

### DIFF
--- a/src/commands/tick-login.js
+++ b/src/commands/tick-login.js
@@ -39,7 +39,14 @@ function login(argv) {
     server.login(user)
     .then(user => setUser(user))
     .then(() => console.log('You\'re logged in now'))
-    .catch(err => console.error(formatError(err)))
+    .catch(err => {
+      // Server returns status 400 if no username or password is provided
+      if ([400, 403].includes(err.response.status)) {
+        console.error('Invalid username or password')
+      } else {
+        console.error(formatError(err))
+      }
+    })
   })
 
 }


### PR DESCRIPTION
Changes the error message to `Invalid username or password` if the user enters incorrect credentials, instead of `Error Request failed with status code 403` as it was previously.

Resolves #384