### PR TITLE
Add missing `chalk` import

### DIFF
--- a/src/remove.js
+++ b/src/remove.js
@@ -1,4 +1,5 @@
 import _ from 'lodash'
+import chalk from 'chalk'
 
 export default removeEntries
 


### PR DESCRIPTION
`remove.js` was missing an import to chalk, causing error messages to be lost when an actual error occurred during the removal process

Resolves #383